### PR TITLE
fix: correct CSS generated code

### DIFF
--- a/theme/utils.ts
+++ b/theme/utils.ts
@@ -277,7 +277,7 @@ export function parseColors(colors: Color[]) {
   const formattedColors = colors.map((colorObj) => {
     const { varName, colorHsl } = colorObj;
     const { h, s, l } = colorHsl;
-    const formattedColor = `\t\t${varName}: ${h} ${s}% ${l}%`;
+    const formattedColor = `\t\t${varName}: ${h} ${s}% ${l}%;`;
     return formattedColor;
   });
 


### PR DESCRIPTION
When generating the code for CSS colors, the current generated code does not
include `;` at the end of each color line. This PR fix such issue.


<details>
<summary>Currently generated CSS output</summary>


```css
@layer base {
    :root {
	--background: 0 0% 100%
	--foreground: 240 10% 3.9%
	--card: 0 0% 100%
	--card-foreground: 240 10% 3.9%
	--popover: 0 0% 100%
	--popover-foreground: 240 10% 3.9%
	--primary: 346.8 77.2% 49.8%
	--primary-foreground: 355.7 100% 97.3%
	--secondary: 240 4.8% 95.9%
	--secondary-foreground: 240 5.9% 10%
	--muted: 240 4.8% 95.9%
	--muted-foreground: 240 3.8% 46.1%
	--accent: 240 4.8% 95.9%
	--accent-foreground: 240 5.9% 10%
	--destructive: 0 84.2% 60.2%
	--destructive-foreground: 0 0% 98%
	--border: 240 5.9% 90%
	--input: 240 5.9% 90%
	--ring: 346.8 77.2% 49.8%
        --radius: 0.5rem
    }

    .dark {
    	--background: 20 14.3% 4.1%
    	--foreground: 0 0% 95%
    	--card: 24 9.8% 10%
    	--card-foreground: 0 0% 95%
    	--popover: 0 0% 9%
    	--popover-foreground: 0 0% 95%
    	--primary: 346.8 77.2% 49.8%
    	--primary-foreground: 355.7 100% 97.3%
    	--secondary: 240 3.7% 15.9%
    	--secondary-foreground: 0 0% 98%
    	--muted: 0 0% 15%
    	--muted-foreground: 240 5% 64.9%
    	--accent: 12 6.5% 15.1%
    	--accent-foreground: 0 0% 98%
    	--destructive: 0 62.8% 30.6%
    	--destructive-foreground: 0 85.7% 97.3%
    	--border: 240 3.7% 15.9%
    	--input: 240 3.7% 15.9%
    	--ring: 346.8 77.2% 49.8%
    }
}
```

</details>

<details>
<summary>Fixed generated CSS</summary>

```css
@layer base {
    :root {
	--background: 0 0% 100%;
	--foreground: 240 10% 3.9%;
	--card: 0 0% 100%;
	--card-foreground: 240 10% 3.9%;
	--popover: 0 0% 100%;
	--popover-foreground: 240 10% 3.9%;
	--primary: 346.8 77.2% 49.8%;
	--primary-foreground: 355.7 100% 97.3%;
	--secondary: 240 4.8% 95.9%;
	--secondary-foreground: 240 5.9% 10%;
	--muted: 240 4.8% 95.9%;
	--muted-foreground: 240 3.8% 46.1%;
	--accent: 240 4.8% 95.9%;
	--accent-foreground: 240 5.9% 10%;
	--destructive: 0 84.2% 60.2%;
	--destructive-foreground: 0 0% 98%;
	--border: 240 5.9% 90%;
	--input: 240 5.9% 90%;
	--ring: 346.8 77.2% 49.8%;
        --radius: 0.5rem;
    }

    .dark {
    	--background: 20 14.3% 4.1%;
    	--foreground: 0 0% 95%;
    	--card: 24 9.8% 10%;
    	--card-foreground: 0 0% 95%;
    	--popover: 0 0% 9%;
    	--popover-foreground: 0 0% 95%;
    	--primary: 346.8 77.2% 49.8%;
    	--primary-foreground: 355.7 100% 97.3%;
    	--secondary: 240 3.7% 15.9%;
    	--secondary-foreground: 0 0% 98%;
    	--muted: 0 0% 15%;
    	--muted-foreground: 240 5% 64.9%;
    	--accent: 12 6.5% 15.1%;
    	--accent-foreground: 0 0% 98%;
    	--destructive: 0 62.8% 30.6%;
    	--destructive-foreground: 0 85.7% 97.3%;
    	--border: 240 3.7% 15.9%;
    	--input: 240 3.7% 15.9%;
    	--ring: 346.8 77.2% 49.8%;
    }
}
```

</details>

---

Thanks for working on the project, works really nice and its UI is brilliant. I
will try to spread the word as it is probably one of the bests works I was able
to find like this